### PR TITLE
updated crossplane aws provider to 0.27.0

### DIFF
--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -53,7 +53,7 @@ To understand this repository in detail you can follow the blog piece here: [Cre
 
 9. Install the AWS Crossplane provider in your cluster
    ```
-   kubectl crossplane install provider crossplane/provider-aws:v0.22.0
+   kubectl crossplane install provider crossplane/provider-aws:v0.27.0
    ```
 
 10. Create the Provider Configuration


### PR DESCRIPTION
Thank you for this excellent guide! When following your steps and describing my instance, I get the warning "cannot update Instance custom resource: Operation cannot be fulfilled on instances.ec2.aws.crossplane.io". 

To fix this, I updated the aws provider to 0.27.0 and no longer received this warning message. 